### PR TITLE
All registries are insecure

### DIFF
--- a/coreos/deis/deis-cloud-init-with-disk.yml
+++ b/coreos/deis/deis-cloud-init-with-disk.yml
@@ -103,7 +103,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
         [Service]
-        Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16"
+        Environment="DOCKER_OPTS=--insecure-registry 0.0.0.0/0"
   - path: /run/deis/bin/get_image
     permissions: '0755'
     content: |


### PR DESCRIPTION
Azure doesn't follow RFC1918, which means it uses publicly-routable
IP addresses in private networks. This is bad for lots of reasons,
but the one concerning us is that it breaks Deis pushes:

```
[info] POST /v1.15/images/100.74.122.55:5000/karmic-nailhead/push?tag=git-7643b9e2
[bbf62d6b] +job push(100.74.122.55:5000/karmic-nailhead)
Invalid registry endpoint https://100.74.122.55:5000/v1/: Get https://100.74.122.55:5000/v1/_ping: EOF. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry 100.74.122.55:5000` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/100.74.122.55:5000/ca.crt
[bbf62d6b] -job push(100.74.122.55:5000/karmic-nailhead) = ERR (1)
```

We have to tell the Docker daemons on Azure that all registries are
insecure, since we don't know what IP ranges the Deis registry
will be in.
