### PR TITLE
Fix endpoint probe creation for Deis

### DIFF
--- a/coreos/cluster/azure-coreos-cluster
+++ b/coreos/cluster/azure-coreos-cluster
@@ -131,14 +131,18 @@ def linux_config(hostname, args):
     system.disable_ssh_password_authentication = True
     return system
 
-def endpoint_config(name, port):
+def endpoint_config(name, port, probe=False):
     endpoint = ConfigurationSetInputEndpoint(name, 'tcp', port, port, name)
-    load_balancer_probe = LoadBalancerProbe()
-    load_balancer_probe.path = 'health-check'
-    load_balancer_probe.port = port
-    load_balancer_probe.protocol = 'http'
-    endpoint.load_balancer_probe = load_balancer_probe
+    if probe:
+      endpoint.load_balancer_probe = probe
     return endpoint
+
+def load_balancer_probe(path, port, protocol):
+    load_balancer_probe = LoadBalancerProbe()
+    load_balancer_probe.path = path
+    load_balancer_probe.port = port
+    load_balancer_probe.protocol = protocol
+    return load_balancer_probe
 
 def network_config(subnet_name=None, port='59913', public_ip_name=None):
     network = ConfigurationSet()
@@ -150,8 +154,10 @@ def network_config(subnet_name=None, port='59913', public_ip_name=None):
     if public_ip_name:
         network.public_ips.public_ips.append(PublicIP(name=public_ip_name))
     if args.deis:
-        network.input_endpoints.input_endpoints.append(endpoint_config('http', '80'))
-        network.input_endpoints.input_endpoints.append(endpoint_config('deis', '2222'))
+        # create web endpoint with probe checking /health-check
+        network.input_endpoints.input_endpoints.append(endpoint_config('web', '80', load_balancer_probe('/health-check', '80', 'http')))
+        # create builder endpoint with no health check
+        network.input_endpoints.input_endpoints.append(endpoint_config('builder', '2222', load_balancer_probe(None, '2222', 'tcp')))
     return network
 
 def data_hd(target_container_url, target_blob_name, target_lun, target_disk_size_in_gb):


### PR DESCRIPTION
Without this change, the builder output has a bunch of output like:
```
Feb 07 00:09:02 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.152.72 port 41545
Feb 07 00:09:08 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 172.17.42.1 port 53538
Feb 07 00:09:15 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.204.14 port 47759
Feb 07 00:09:17 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.152.72 port 41583
Feb 07 00:09:23 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 172.17.42.1 port 53623
Feb 07 00:09:30 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.204.14 port 47799
Feb 07 00:09:32 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.152.72 port 41619
Feb 07 00:09:38 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 172.17.42.1 port 53700
Feb 07 00:09:45 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.204.14 port 47846
Feb 07 00:09:47 feb6-coreos-1 sh[5974]: Bad protocol version identification 'GET /health-check HTTP/1.1' from 100.72.152.72 port 41658
```
due to the probe incorrectly querying health-check for the builder using HTTP.

See https://github.com/deis/deis/pull/2893#issuecomment-73337422